### PR TITLE
T-110 / Mapping data from Cart entity to CheckoutItemDto

### DIFF
--- a/src/main/java/com/kuna_backend/controllers/PaymentController.java
+++ b/src/main/java/com/kuna_backend/controllers/PaymentController.java
@@ -1,6 +1,5 @@
 package com.kuna_backend.controllers;
 
-import com.kuna_backend.dtos.checkout.CheckoutItemDto;
 import com.kuna_backend.dtos.checkout.StripeResponse;
 import com.kuna_backend.exceptions.AuthenticationFailException;
 import com.kuna_backend.models.Client;
@@ -15,7 +14,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,9 +32,13 @@ public class PaymentController {
 
     // Stripe Create Session Api
     @PostMapping("/create-checkout-session")
-    public ResponseEntity<StripeResponse> checkoutList(@RequestBody List<CheckoutItemDto> checkoutItemDtoList) throws StripeException {
+    public ResponseEntity<StripeResponse> checkoutList(@RequestParam("token") String token) throws AuthenticationFailException, StripeException {
+
+        authenticationService.authenticate(token);
+        Client client = authenticationService.getClient(token);
+
         // Create the Stripe session
-        Session session = paymentService.createSession(checkoutItemDtoList);
+        Session session = paymentService.createSession(client);
         StripeResponse stripeResponse = new StripeResponse(session.getId());
         // Send the Stripe session id in response
         return new ResponseEntity<StripeResponse>(stripeResponse, HttpStatus.OK);

--- a/src/main/java/com/kuna_backend/controllers/PaymentController.java
+++ b/src/main/java/com/kuna_backend/controllers/PaymentController.java
@@ -32,7 +32,7 @@ public class PaymentController {
 
     // Stripe Create Session Api
     @PostMapping("/create-checkout-session")
-    public ResponseEntity<StripeResponse> checkoutList(@RequestParam("token") String token) throws AuthenticationFailException, StripeException {
+    public ResponseEntity<StripeResponse> checkoutList(@RequestParam("token") String token) throws AuthenticationFailException,  StripeException {
 
         authenticationService.authenticate(token);
         Client client = authenticationService.getClient(token);

--- a/src/main/java/com/kuna_backend/dtos/cart/CartItemDto.java
+++ b/src/main/java/com/kuna_backend/dtos/cart/CartItemDto.java
@@ -20,10 +20,6 @@ public class CartItemDto {
         this.setProductVariation(cart.getProductVariation());
     }
 
-    // TODO : Implement method for transfering data from CartItemDto to Checkout Item dto.
-//    public CheckoutItemDto toCheckoutItemDto {
-//    }
-
     @Override
     public String toString() {
         return "CartDto{" +

--- a/src/main/java/com/kuna_backend/dtos/checkout/CheckoutItemDto.java
+++ b/src/main/java/com/kuna_backend/dtos/checkout/CheckoutItemDto.java
@@ -1,5 +1,7 @@
 package com.kuna_backend.dtos.checkout;
 
+import com.kuna_backend.models.Cart;
+
 public class CheckoutItemDto {
 
     private String productName;
@@ -11,12 +13,12 @@ public class CheckoutItemDto {
     public CheckoutItemDto() {
     }
 
-    public CheckoutItemDto(String productName, int quantity, double price, Long productVariationId, Long clientId) {
-        this.productName = productName;
-        this.quantity = quantity;
-        this.price = price;
-        this.productVariationId = productVariationId;
-        this.clientId = clientId;
+    public CheckoutItemDto(Cart cart) {
+        this.productName = cart.getProductVariation().getProduct().getName();
+        this.quantity = cart.getQuantity();
+        this.price = cart.getProductVariation().getProduct().getPrice();
+        this.productVariationId = cart.getProductVariation().getId();
+        this.clientId = cart.getClient().getId();
     }
 
     public String getProductName() {

--- a/src/main/java/com/kuna_backend/dtos/checkout/CheckoutItemDto.java
+++ b/src/main/java/com/kuna_backend/dtos/checkout/CheckoutItemDto.java
@@ -8,7 +8,6 @@ public class CheckoutItemDto {
     private int quantity;
     private double price;
     private Long productVariationId;
-    private Long clientId;
 
     public CheckoutItemDto() {
     }
@@ -18,7 +17,6 @@ public class CheckoutItemDto {
         this.quantity = cart.getQuantity();
         this.price = cart.getProductVariation().getProduct().getPrice();
         this.productVariationId = cart.getProductVariation().getId();
-        this.clientId = cart.getClient().getId();
     }
 
     public String getProductName() {
@@ -53,11 +51,4 @@ public class CheckoutItemDto {
         this.productVariationId = productVariationId;
     }
 
-    public Long getClientId() {
-        return clientId;
-    }
-
-    public void setClientId(Long clientId) {
-        this.clientId = clientId;
-    }
 }

--- a/src/main/java/com/kuna_backend/services/PaymentService.java
+++ b/src/main/java/com/kuna_backend/services/PaymentService.java
@@ -1,8 +1,10 @@
 package com.kuna_backend.services;
 
 import com.kuna_backend.dtos.checkout.CheckoutItemDto;
+import com.kuna_backend.models.Cart;
 import com.kuna_backend.models.Client;
 import com.kuna_backend.models.Payment;
+import com.kuna_backend.repositories.CartRepository;
 import com.kuna_backend.repositories.PaymentRepository;
 import com.stripe.Stripe;
 import com.stripe.exception.StripeException;
@@ -23,6 +25,9 @@ public class PaymentService {
 
     @Autowired
     public PaymentRepository paymentRepository;
+
+    @Autowired
+    private CartRepository cartRepository;
 
     @Value("${BASE_URL}")
     public String baseURL;
@@ -55,7 +60,7 @@ public class PaymentService {
     }
 
     // Create Session from list of Checkout items
-    public Session createSession(List<CheckoutItemDto> checkoutItemDtoList) throws StripeException {
+    public Session createSession(Client client) throws StripeException {
 
         // Supply Success and Failure url for Stripe
         String successURL = baseURL + "payment/success";
@@ -65,9 +70,11 @@ public class PaymentService {
         Stripe.apiKey = apiKey;
 
         List<SessionCreateParams.LineItem> sessionItemList = new ArrayList<>();
+        List<Cart> cartList = cartRepository.findAllByClientOrderByCreatedAtDesc(client);
 
         // For each product compute SessionCreateParams.LineItem
-        for (CheckoutItemDto checkoutItemDto : checkoutItemDtoList) {
+        for (Cart cart : cartList){
+            CheckoutItemDto checkoutItemDto = getDtoFromCart(cart);
             sessionItemList.add(createSessionLineItem(checkoutItemDto));
         }
 
@@ -81,6 +88,10 @@ public class PaymentService {
                 .build();
         return Session.create(params);
 
+    }
+
+    public static CheckoutItemDto getDtoFromCart (Cart cart) {
+        return new CheckoutItemDto(cart);
     }
 
     // Save Payment after Checkout session

--- a/src/main/java/com/kuna_backend/services/PaymentService.java
+++ b/src/main/java/com/kuna_backend/services/PaymentService.java
@@ -90,7 +90,7 @@ public class PaymentService {
 
     }
 
-    public static CheckoutItemDto getDtoFromCart (Cart cart) {
+    public static CheckoutItemDto getDtoFromCart(Cart cart) {
         return new CheckoutItemDto(cart);
     }
 

--- a/src/test/java/com/kuna_backend/CartServiceTest.java
+++ b/src/test/java/com/kuna_backend/CartServiceTest.java
@@ -77,7 +77,7 @@ public class CartServiceTest {
         productVariation1.setProduct(product1);
 
         ProductVariation productVariation2 = new ProductVariation();
-        productVariation2.setProduct(product2);;
+        productVariation2.setProduct(product2);
 
         Cart cart1 = new Cart();
         cart1.setProductVariation(productVariation1);

--- a/src/test/java/com/kuna_backend/PaymentServiceTest.java
+++ b/src/test/java/com/kuna_backend/PaymentServiceTest.java
@@ -151,13 +151,9 @@ public class PaymentServiceTest {
         productVariation.setId(1L);
         productVariation.setProduct(product);
 
-        Client client = new Client();
-        client.setId(1L);
-
         Cart cart = new Cart();
         cart.setQuantity(4);
         cart.setProductVariation(productVariation);
-        cart.setClient(client);
 
         CheckoutItemDto checkoutItemDto = PaymentService.getDtoFromCart(cart);
 
@@ -165,7 +161,6 @@ public class PaymentServiceTest {
         assertEquals(cart.getQuantity(), checkoutItemDto.getQuantity());
         assertEquals(cart.getProductVariation().getProduct().getPrice(), checkoutItemDto.getPrice());
         assertEquals(cart.getProductVariation().getId(), checkoutItemDto.getProductVariationId());
-        assertEquals(cart.getClient().getId(), checkoutItemDto.getClientId());
 
     }
 

--- a/src/test/java/com/kuna_backend/PaymentServiceTest.java
+++ b/src/test/java/com/kuna_backend/PaymentServiceTest.java
@@ -1,8 +1,12 @@
 package com.kuna_backend;
 
 import com.kuna_backend.dtos.checkout.CheckoutItemDto;
+import com.kuna_backend.models.Cart;
 import com.kuna_backend.models.Client;
 import com.kuna_backend.models.Payment;
+import com.kuna_backend.models.Product;
+import com.kuna_backend.models.ProductVariation;
+import com.kuna_backend.repositories.CartRepository;
 import com.kuna_backend.repositories.PaymentRepository;
 import com.kuna_backend.services.PaymentService;
 import com.stripe.Stripe;
@@ -41,7 +45,13 @@ public class PaymentServiceTest {
     private PaymentRepository paymentRepository;
 
     @Mock
+    private CartRepository cartRepository;
+
+    @Mock
     public Session session;
+
+    @Mock
+    public Client client;
 
     @InjectMocks
     private PaymentService paymentService;
@@ -89,10 +99,13 @@ public class PaymentServiceTest {
         String successURL = paymentService.baseURL + "payment/success";
         String failureURL = paymentService.baseURL + "payment/failed";
 
+        List<Cart> cartList = new ArrayList<>();
+
+        when(cartRepository.findAllByClientOrderByCreatedAtDesc(client)).thenReturn(cartList);
+
         SessionCreateParams.Builder paramsBuilder = mock(SessionCreateParams.Builder.class);
         SessionCreateParams params = mock(SessionCreateParams.class);
         Session session = mock(Session.class);
-        List<CheckoutItemDto> checkoutItemDtoList = new ArrayList<>();
 
         // Mock the static methods
         try (MockedStatic<SessionCreateParams> sessionBuilderMock = mockStatic(SessionCreateParams.class);
@@ -111,7 +124,7 @@ public class PaymentServiceTest {
             // Stub the Session.create method
             sessionMock.when(() -> Session.create(params)).thenReturn(session);
 
-            Session result = paymentService.createSession(checkoutItemDtoList);
+            Session result = paymentService.createSession(client);
 
             assertEquals(session, result);
             verify(paramsBuilder).addPaymentMethodType(SessionCreateParams.PaymentMethodType.CARD);
@@ -120,11 +133,40 @@ public class PaymentServiceTest {
             verify(paramsBuilder).addAllLineItem(any());
             verify(paramsBuilder).setSuccessUrl(successURL);
             verify(paramsBuilder).build();
+            verify(cartRepository).findAllByClientOrderByCreatedAtDesc(client);
 
             // Verify the static method call
             sessionMock.verify(() -> Session.create(params));
-
         }
+    }
+
+    @Test
+    public void getDtoFromCart() {
+
+        Product product = new Product();
+        product.setName("Body");
+        product.setPrice(20.0);
+
+        ProductVariation productVariation = new ProductVariation();
+        productVariation.setId(1L);
+        productVariation.setProduct(product);
+
+        Client client = new Client();
+        client.setId(1L);
+
+        Cart cart = new Cart();
+        cart.setQuantity(4);
+        cart.setProductVariation(productVariation);
+        cart.setClient(client);
+
+        CheckoutItemDto checkoutItemDto = PaymentService.getDtoFromCart(cart);
+
+        assertEquals(cart.getProductVariation().getProduct().getName(), checkoutItemDto.getProductName());
+        assertEquals(cart.getQuantity(), checkoutItemDto.getQuantity());
+        assertEquals(cart.getProductVariation().getProduct().getPrice(), checkoutItemDto.getPrice());
+        assertEquals(cart.getProductVariation().getId(), checkoutItemDto.getProductVariationId());
+        assertEquals(cart.getClient().getId(), checkoutItemDto.getClientId());
+
     }
 
     @Test


### PR DESCRIPTION
Refactored Create Checkout Session method from Payment Service and Controller, in order to directly retrieve the data from the Cart instance for the initialization of the CheckoutItemDtos. Therefore, it is no longer necessary to request data input (@RequestBody) from the frontend but only to request the token from the Client who is associated with the Cart instance. 

- Eliminated the clientId attribute from CheckoutItemDto, since the Client is directly retrieved with the token authentication and save it into the Payment database. 