### PR TITLE
T-111 / Refactored payment status method

### DIFF
--- a/src/main/java/com/kuna_backend/enums/PaymentStatus.java
+++ b/src/main/java/com/kuna_backend/enums/PaymentStatus.java
@@ -1,0 +1,7 @@
+package com.kuna_backend.enums;
+
+public enum PaymentStatus {
+
+    UNPAID,
+    PAID
+}

--- a/src/main/java/com/kuna_backend/models/Payment.java
+++ b/src/main/java/com/kuna_backend/models/Payment.java
@@ -1,7 +1,10 @@
 package com.kuna_backend.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.kuna_backend.enums.PaymentStatus;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.Id;
@@ -33,7 +36,8 @@ public class Payment {
     private String stripeToken;
 
     @Column (name = "payment_status", length = 64)
-    private String paymentStatus;
+    @Enumerated(EnumType.STRING)
+    private PaymentStatus paymentStatus;
 
     @Column (name = "provider", length = 64)
     private String provider;
@@ -55,7 +59,7 @@ public class Payment {
     @OneToOne(mappedBy = "payment")
     private Order order;
 
-    public Payment(Long id, float amount, String currency, String stripeToken, String paymentStatus, String provider, Date paymentDate, LocalDateTime lastUpdate, Client client, Order order) {
+    public Payment(Long id, float amount, String currency, String stripeToken, PaymentStatus paymentStatus, String provider, Date paymentDate, LocalDateTime lastUpdate, Client client, Order order) {
         this.id = id;
         this.amount = amount;
         this.currency = currency;
@@ -104,11 +108,11 @@ public class Payment {
         this.stripeToken = stripeToken;
     }
 
-    public String getPaymentStatus() {
+    public PaymentStatus getPaymentStatus() {
         return paymentStatus;
     }
 
-    public void setPaymentStatus(String paymentStatus) {
+    public void setPaymentStatus(PaymentStatus paymentStatus) {
         this.paymentStatus = paymentStatus;
     }
 

--- a/src/main/java/com/kuna_backend/services/PaymentService.java
+++ b/src/main/java/com/kuna_backend/services/PaymentService.java
@@ -1,6 +1,7 @@
 package com.kuna_backend.services;
 
 import com.kuna_backend.dtos.checkout.CheckoutItemDto;
+import com.kuna_backend.enums.PaymentStatus;
 import com.kuna_backend.models.Cart;
 import com.kuna_backend.models.Client;
 import com.kuna_backend.models.Payment;
@@ -105,7 +106,7 @@ public class PaymentService {
         payment.setAmount(session.getAmountTotal() / 100.0f);
         payment.setCurrency(session.getCurrency().toUpperCase());
         payment.setStripeToken(session.getId());
-        payment.setPaymentStatus(session.getPaymentStatus().toUpperCase());
+        payment.setPaymentStatus(PaymentStatus.PAID);
         payment.setProvider("Stripe");
         payment.setPaymentDate(new Date(session.getCreated() * 1000L));
         payment.setClient(client);

--- a/src/test/java/com/kuna_backend/PaymentServiceTest.java
+++ b/src/test/java/com/kuna_backend/PaymentServiceTest.java
@@ -1,6 +1,7 @@
 package com.kuna_backend;
 
 import com.kuna_backend.dtos.checkout.CheckoutItemDto;
+import com.kuna_backend.enums.PaymentStatus;
 import com.kuna_backend.models.Cart;
 import com.kuna_backend.models.Client;
 import com.kuna_backend.models.Payment;
@@ -175,7 +176,7 @@ public class PaymentServiceTest {
             when(session.getAmountTotal()).thenReturn(1000L);
             when(session.getCurrency()).thenReturn("usd");
             when(session.getId()).thenReturn(stripeToken);
-            when(session.getPaymentStatus()).thenReturn("paid");
+            when(session.getPaymentStatus()).thenReturn("PAID");
             when(session.getCreated()).thenReturn(System.currentTimeMillis() / 1000L);
 
             Client clientMock = mock(Client.class);
@@ -187,7 +188,7 @@ public class PaymentServiceTest {
                     payment.getAmount() == 10.0f &&
                             payment.getCurrency().equals("USD") &&
                             payment.getStripeToken().equals(stripeToken) &&
-                            payment.getPaymentStatus().equals("PAID") &&
+                            payment.getPaymentStatus().equals(PaymentStatus.PAID) &&
                             payment.getProvider().equals("Stripe") &&
                             payment.getClient() == clientMock
             ));


### PR DESCRIPTION
Refactored savePayment method in order to set the Payment status to PAID after creating the checkout session with Stripe and after the payment is completed. This way, the payment Status will be set and saved into the database. 